### PR TITLE
Fix missing source file warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "es5",
     "lib": ["es6", "dom"],
     "sourceMap": true,
+    "inlineSources": true,
     "moduleResolution": "node",
     "rootDir": "src",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Fixes missing file warnings stemming from source map files.

Rel: https://github.com/geostyler/geostyler-style/pull/297